### PR TITLE
Remove unfounded innuendo about dictionaries.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Umím jen anglicky a potřebuju jen tenhle slovník, takže ne, ale pull request
 
 ### Chci jazyk XYZ
 
-Mohu tě odkázat na program od Vaška Slavíka https://dictionaries.io/ který za lidových 599,- korun českých nabízí přes 80 jazyků. Původ a licence korpusu je ovšem neznámá, trošku to smrdí... ;-)
+Mohu tě odkázat na program od Vaška Slavíka https://dictionaries.io/ který za lidových 599,- korun českých nabízí přes 80 jazyků.
 
 ## LICENCE
 


### PR DESCRIPTION
Slovníková data Dictionaries jsou odvozené dílo Wiktionary, distribuované pod CC BY-SA 3.0. Tvrdit, že původ a licence jsou "neznámé" mi přijde dost odvážné, když obojí aplikace *výslovně* uvádí:

<img width="737" alt="Screen Shot 2022-07-23 at 14 12 11" src="https://user-images.githubusercontent.com/145881/180604776-5b27451e-beec-4741-924f-e56c9a9288ec.png">

Stejná metadata se ukazují v Dictionary.app.

Dělám Open Source přes [dvacet](https://github.com/vslavik/poedit) [let](https://wxwidgets.org). V životě bych si nedovolil porušovat něčí licenci, jak naznačujete.

Toto PR dělá minimální změny k odstranění téhle pomluvy. Ocenil bych, kdybyste ho buď přijal, nebo odstranil celý text o dictionaries.io.

P.S. macOS Ventura bude obsahovat licencovaný překladový EN-CS slovník od Lingea s.r.o., takže ani vaše, ani moje práce už nebude od podzimu pro české uživatele potřeba.